### PR TITLE
Fixes and changes for users/organizations

### DIFF
--- a/splight_abstract/endpoints/__init__.py
+++ b/splight_abstract/endpoints/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from requests import Session
+from requests import Session, JSONDecodeError
 
 
 class BaseEndpoint:
@@ -8,6 +8,12 @@ class BaseEndpoint:
         self._session = session
         self._base_url = base_url
         self._url = f"{self._base_url.strip('/')}/{self.PATH.strip('/')}/"
+
+    def _request_content(self, response: Any):
+        try:
+            return response.json() if response.content else None
+        except JSONDecodeError as e:
+            raise Exception(str(response.content))
 
     def _get_request(self, url: str, params: Optional[Dict] = None):
         response = self._session.get(url, params=params)


### PR DESCRIPTION
- Clearer error message when making requests to auth api through auth client
- Fix delete organization
- Patch for users
- Now admin is subset of splightadmin, they were disjoint so far.
- Flushing cache when deleting invitations or users
- Refactor roles: until now, to change users roles, front needed the id, name and description of the role to assign, now all the role information but "name" is hidden, and to change users roles you only need to patch with a list of strings of the roles you want to assign to a user.