### PR TITLE
feat: add __version__ attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import find_packages, setup
 
-# from splight_lib import __version__
-
-
 with open("requirements.txt") as fp:
     install_requires = fp.readlines()
 
@@ -17,7 +14,6 @@ test_requires = [
 
 setup(
     name="splight-lib",
-    # version=__version__,
     version="3.3.8",
     author="Splight",
     author_email="factory@splight-ae.com",

--- a/splight_lib/__init__.py
+++ b/splight_lib/__init__.py
@@ -1,1 +1,3 @@
 from splight_lib.version import __version__
+
+__all__ = [__version__]

--- a/splight_lib/version.py
+++ b/splight_lib/version.py
@@ -1,4 +1,3 @@
 from importlib import metadata
 
 __version__ = metadata.version("splight_lib")
-# __version__ = "3.3.8"


### PR DESCRIPTION
Add `__version__` attribute for the lib, a small change so we can do:
```python
import splight_lib

print(splight_lib.__version__)
```